### PR TITLE
Use POST to request to UserInfo API

### DIFF
--- a/lib/omniauth/strategies/yahoojp.rb
+++ b/lib/omniauth/strategies/yahoojp.rb
@@ -51,7 +51,7 @@ module OmniAuth
 
       def raw_info
         access_token.options[:mode] = :header
-        @raw_info ||= access_token.get('https://userinfo.yahooapis.jp/yconnect/v2/attribute').parsed
+        @raw_info ||= access_token.post('https://userinfo.yahooapis.jp/yconnect/v2/attribute').parsed
       end
 
       def prune!(hash)


### PR DESCRIPTION
According to the following release, after May 2021, UserInfo API will only accept POST requests. https://developer.yahoo.co.jp/changelog/2021-02-03-yconnect.html